### PR TITLE
#2 Fixed not compiling on later versions of Keycloak

### DIFF
--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -86,18 +86,18 @@
     <dependency>
       <groupId>org.keycloak</groupId>
       <artifactId>keycloak-core</artifactId>
-      <version>11.0.2</version>
+      <version>21.1.2</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.keycloak</groupId>
       <artifactId>keycloak-server-spi</artifactId>
-      <version>11.0.2</version>
+      <version>21.1.2</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>
   <properties>
-    <keycloak.version>11.0.2</keycloak.version>
+    <keycloak.version>21.1.2</keycloak.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
-		<keycloak.version>11.0.2</keycloak.version>
+		<keycloak.version>21.1.2</keycloak.version>
 	</properties>
 
 
@@ -21,6 +21,12 @@
 			<version>${keycloak.version}</version>
 			<scope>provided</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-model-legacy</artifactId>
+			<version>${keycloak.version}</version>
+			<scope>provided</scope>
+		</dependency>		
 		<dependency>
 			<groupId>org.keycloak</groupId>
 			<artifactId>keycloak-server-spi</artifactId>

--- a/src/main/java/com/rizky/keycloak/federationdb/FederationDBProvider.java
+++ b/src/main/java/com/rizky/keycloak/federationdb/FederationDBProvider.java
@@ -163,14 +163,14 @@ UserLookupProvider
     }
 
     @Override
-    public UserModel getUserByEmail(String arg0, RealmModel arg1) {
+    public UserModel getUserByEmail(RealmModel realm, String email) {
         // TODO Auto-generated method stub
 
         Connection conn1=null;
         PreparedStatement prep=null;
 
         try	{
-            log1.debug("Get User By Email: "+arg0);
+            log1.debug("Get User By Email: "+email);
 
             String dataSource1=model.getConfig().getFirst("Jndi_Name");
             String query1=model.getConfig().getFirst("User_query");
@@ -180,25 +180,25 @@ UserLookupProvider
 
             conn1=ds.getConnection();
             prep=conn1.prepareStatement(query1);
-            prep.setString(1, arg0);
+            prep.setString(1, email);
 
             ResultSet rs=prep.executeQuery();
 
             if(!rs.next())	{
 
-                log1.info("Email: "+arg0+" not found");
+                log1.info("Email: "+email+" not found");
                 return null;
             }
 
-            UserData userData=new UserData(session, arg1, model);
+            UserData userData=new UserData(session, realm, model);
             userData.setEmail(rs.getString("email"));
             userData.setUsername(rs.getString("email"));
             userData.setFirstName(rs.getString("firstName"));
 
-            UserModel local = session.userLocalStorage().getUserByEmail(arg0, arg1);
+            UserModel local = session.userLocalStorage().getUserByEmail(realm, email);
             if(local==null)	{
                 log1.debug("Local User Not Found, adding user to Local");
-                local = session.userLocalStorage().addUser(arg1, userData.getUsername());
+                local = session.userLocalStorage().addUser(realm, userData.getUsername());
                 local.setFederationLink(model.getId());
                 local.setEmail(userData.getEmail());
                 local.setUsername(userData.getEmail());
@@ -225,7 +225,7 @@ UserLookupProvider
             }
         }
         catch(Exception e)	{
-            log1.error("Error getting user with email: "+arg0,e);
+            log1.error("Error getting user with email: "+email,e);
             return null;
         }
         finally {
@@ -245,15 +245,15 @@ UserLookupProvider
     }
 
     @Override
-    public UserModel getUserById(String arg0, RealmModel arg1) {
+    public UserModel getUserById(RealmModel realm, String id) {
         // TODO Auto-generated method stub
-        return getUserByEmail(arg0, arg1);
+        return getUserByEmail(realm, id);
     }
 
     @Override
-    public UserModel getUserByUsername(String arg0, RealmModel arg1) {
+    public UserModel getUserByUsername(RealmModel realm, String username) {
         // TODO Auto-generated method stub
-        return getUserByEmail(arg0, arg1);
+        return getUserByEmail(realm, username);
     }
 
 

--- a/src/test/java/com/rizky/keycloak/federationdb/test/FederationDBTest.java
+++ b/src/test/java/com/rizky/keycloak/federationdb/test/FederationDBTest.java
@@ -104,15 +104,15 @@ public class FederationDBTest {
 
 		UserProvider uProv=Mockito.mock(UserProvider.class);
 		Mockito.when(session.userLocalStorage()).thenReturn(uProv);
-		Mockito.when(uProv.getUserByEmail(Mockito.anyString(), Mockito.any())).thenReturn(null);
+		Mockito.when(uProv.getUserByEmail(Mockito.any(), Mockito.anyString())).thenReturn(null);
 		Mockito.when(uProv.addUser(Mockito.any(), Mockito.anyString())).thenReturn(userData);
 
-		UserModel return1=fdbProvider.getUserByEmail(emailValue, rModel);
+		UserModel return1=fdbProvider.getUserByEmail(rModel, emailValue);
 		
 		Assert.assertThat(return1.getEmail(), CoreMatchers.is(emailValue));
 		
 		Mockito.when(rs.next()).thenReturn(false);
-		UserModel return2=fdbProvider.getUserByEmail(emailValueFalse, rModel);
+		UserModel return2=fdbProvider.getUserByEmail(rModel, emailValueFalse);
 		
 		Assert.assertThat(return2, CoreMatchers.is(IsNull.nullValue()));
 


### PR DESCRIPTION
Added keycloak-model-legacy dependency for backwards compatibility
Updated version to 21.1.2 (as this is the current stable version)
The realm argument is now first in the Keycloak UserLookupProvider class and therefore the FederationDBProvider has been updated with these changes. Also arg0 and arg1 was renamed to proper names.